### PR TITLE
feat: add @napi-rs/canvas support to VideoFrame constructor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,20 +10,20 @@ WebCodecs API implementation for Node.js using FFmpeg, built with napi-rs (Rust 
 
 **Status:** Feature-complete, production-ready
 
-| Component           | Status      | Notes                                              |
-| ------------------- | ----------- | -------------------------------------------------- |
-| VideoEncoder        | ✅ Complete | H.264, H.265, VP8, VP9, AV1 + EventTarget          |
-| VideoDecoder        | ✅ Complete | All codecs + AV1 drain + EventTarget               |
-| AudioEncoder        | ✅ Complete | AAC, Opus, MP3, FLAC + EventTarget                 |
-| AudioDecoder        | ✅ Complete | All codecs with resampling + EventTarget           |
-| VideoFrame          | ✅ Complete | All pixel formats, async copyTo, format conversion |
-| AudioData           | ✅ Complete | All sample formats                                 |
-| ImageDecoder        | ✅ Complete | JPEG, PNG, WebP, GIF, BMP, AVIF                    |
-| Threading           | ✅ Complete | Non-blocking Drop, proper lifecycle                |
-| W3C Spec Compliance | ✅ Complete | All APIs aligned                                   |
-| Type Definitions    | ✅ Complete | ~1,100 lines in index.d.ts                         |
-| Test Coverage       | ✅ Complete | 917 tests (34 files), all passing                  |
-| Hardware Encoding   | ✅ Complete | Zero-copy GPU path, auto-tuning                    |
+| Component           | Status      | Notes                                                              |
+| ------------------- | ----------- | ------------------------------------------------------------------ |
+| VideoEncoder        | ✅ Complete | H.264, H.265, VP8, VP9, AV1 + EventTarget                          |
+| VideoDecoder        | ✅ Complete | All codecs + AV1 drain + EventTarget                               |
+| AudioEncoder        | ✅ Complete | AAC, Opus, MP3, FLAC + EventTarget                                 |
+| AudioDecoder        | ✅ Complete | All codecs with resampling + EventTarget                           |
+| VideoFrame          | ✅ Complete | All pixel formats, async copyTo, format conversion, Canvas support |
+| AudioData           | ✅ Complete | All sample formats                                                 |
+| ImageDecoder        | ✅ Complete | JPEG, PNG, WebP, GIF, BMP, AVIF                                    |
+| Threading           | ✅ Complete | Non-blocking Drop, proper lifecycle                                |
+| W3C Spec Compliance | ✅ Complete | All APIs aligned                                                   |
+| Type Definitions    | ✅ Complete | ~1,100 lines in index.d.ts                                         |
+| Test Coverage       | ✅ Complete | 917 tests (34 files), all passing                                  |
+| Hardware Encoding   | ✅ Complete | Zero-copy GPU path, auto-tuning                                    |
 
 **Remaining Work:** None - All core features complete.
 
@@ -295,7 +295,18 @@ const frame = new VideoFrame(data, {
 
 // From existing VideoFrame (clone with optional overrides)
 const cloned = new VideoFrame(sourceFrame, { timestamp: newTs })
+
+// From @napi-rs/canvas Canvas (timestamp required per W3C spec)
+import { createCanvas } from '@napi-rs/canvas'
+const canvas = createCanvas(1920, 1080)
+const ctx = canvas.getContext('2d')
+ctx.fillStyle = '#FF0000'
+ctx.fillRect(0, 0, 1920, 1080)
+const canvasFrame = new VideoFrame(canvas, { timestamp: 0 })
+// canvasFrame.format === 'RGBA', colorSpace defaults to sRGB
 ```
+
+**Note:** `@napi-rs/canvas` is an optional peer dependency. Canvas pixel data is copied as RGBA format with sRGB color space.
 
 ## ImageDecoder Usage
 

--- a/__test__/video-frame-canvas.spec.ts
+++ b/__test__/video-frame-canvas.spec.ts
@@ -1,0 +1,324 @@
+/**
+ * VideoFrame Canvas API Conformance Tests
+ *
+ * Tests VideoFrame creation from @napi-rs/canvas Canvas objects.
+ *
+ * Skipped on aarch64-windows where @napi-rs/canvas is not available.
+ */
+
+import test from 'ava'
+
+import { VideoFrame, VideoEncoder, EncodedVideoChunk } from '../index.js'
+
+// Skip all canvas tests on aarch64-windows (no @napi-rs/canvas support)
+const isAarch64Windows = process.platform === 'win32' && process.arch === 'arm64'
+
+const runTest = isAarch64Windows ? test.skip : test
+
+// Dynamic import to avoid loading canvas on unsupported platforms
+let createCanvas: typeof import('@napi-rs/canvas').createCanvas
+if (!isAarch64Windows) {
+  const canvas = await import('@napi-rs/canvas')
+  createCanvas = canvas.createCanvas
+}
+
+// ============================================================================
+// Constructor Tests - Canvas Source
+// ============================================================================
+
+runTest('VideoFrame: constructor from Canvas with valid timestamp', (t) => {
+  const canvas = createCanvas(320, 240)
+  const ctx = canvas.getContext('2d')
+
+  // Fill with red
+  ctx.fillStyle = '#FF0000'
+  ctx.fillRect(0, 0, 320, 240)
+
+  const frame = new VideoFrame(canvas, { timestamp: 0 })
+
+  t.is(frame.format, 'RGBA')
+  t.is(frame.codedWidth, 320)
+  t.is(frame.codedHeight, 240)
+  t.is(frame.displayWidth, 320)
+  t.is(frame.displayHeight, 240)
+  t.is(frame.timestamp, 0)
+
+  frame.close()
+})
+
+runTest('VideoFrame: Canvas requires timestamp in init', (t) => {
+  const canvas = createCanvas(100, 100)
+
+  // Missing init entirely
+  t.throws(
+    () => {
+      new VideoFrame(canvas, undefined as never)
+    },
+    { message: /timestamp is required/ },
+  )
+
+  // Init without timestamp
+  t.throws(
+    () => {
+      new VideoFrame(canvas, {} as never)
+    },
+    { message: /timestamp is required/ },
+  )
+})
+
+// Note: @napi-rs/canvas clamps zero dimensions to default values (e.g., 0 -> 350),
+// so we use mock canvas objects to test our validation code.
+
+runTest('VideoFrame: Canvas with zero width throws', (t) => {
+  // Mock canvas object with zero width
+  const mockCanvas = {
+    width: 0,
+    height: 100,
+    data: () => Buffer.alloc(0),
+  }
+
+  t.throws(
+    () => {
+      new VideoFrame(mockCanvas as never, { timestamp: 0 })
+    },
+    { message: /Canvas width must be greater than 0/ },
+  )
+})
+
+runTest('VideoFrame: Canvas with zero height throws', (t) => {
+  // Mock canvas object with zero height
+  const mockCanvas = {
+    width: 100,
+    height: 0,
+    data: () => Buffer.alloc(0),
+  }
+
+  t.throws(
+    () => {
+      new VideoFrame(mockCanvas as never, { timestamp: 0 })
+    },
+    { message: /Canvas height must be greater than 0/ },
+  )
+})
+
+runTest('VideoFrame: Canvas with zero width and height throws', (t) => {
+  // Mock canvas object with both zero dimensions
+  const mockCanvas = {
+    width: 0,
+    height: 0,
+    data: () => Buffer.alloc(0),
+  }
+
+  // Should throw for width first (checked before height)
+  t.throws(
+    () => {
+      new VideoFrame(mockCanvas as never, { timestamp: 0 })
+    },
+    { message: /Canvas width must be greater than 0/ },
+  )
+})
+
+runTest('VideoFrame: Canvas with all init options', (t) => {
+  const canvas = createCanvas(320, 240)
+  const ctx = canvas.getContext('2d')
+
+  // Draw something
+  ctx.fillStyle = '#0000FF'
+  ctx.fillRect(0, 0, 320, 240)
+
+  const frame = new VideoFrame(canvas, {
+    timestamp: 1000,
+    duration: 33333,
+    displayWidth: 640,
+    displayHeight: 480,
+  })
+
+  t.is(frame.format, 'RGBA')
+  t.is(frame.codedWidth, 320)
+  t.is(frame.codedHeight, 240)
+  t.is(frame.timestamp, 1000)
+  t.is(frame.duration, 33333)
+  t.is(frame.displayWidth, 640)
+  t.is(frame.displayHeight, 480)
+
+  frame.close()
+})
+
+runTest('VideoFrame: Canvas with visibleRect', (t) => {
+  const canvas = createCanvas(320, 240)
+  const ctx = canvas.getContext('2d')
+
+  ctx.fillStyle = '#00FF00'
+  ctx.fillRect(0, 0, 320, 240)
+
+  const frame = new VideoFrame(canvas, {
+    timestamp: 0,
+    visibleRect: { x: 10, y: 10, width: 300, height: 220 },
+  })
+
+  t.is(frame.codedWidth, 320)
+  t.is(frame.codedHeight, 240)
+
+  const visibleRect = frame.visibleRect
+  t.is(visibleRect.x, 10)
+  t.is(visibleRect.y, 10)
+  t.is(visibleRect.width, 300)
+  t.is(visibleRect.height, 220)
+
+  frame.close()
+})
+
+runTest('VideoFrame: Canvas pixel data is RGBA', async (t) => {
+  const canvas = createCanvas(2, 2)
+  const ctx = canvas.getContext('2d')
+
+  // Fill with red (RGBA: 255, 0, 0, 255)
+  ctx.fillStyle = '#FF0000'
+  ctx.fillRect(0, 0, 2, 2)
+
+  const frame = new VideoFrame(canvas, { timestamp: 0 })
+
+  // Copy the data to verify format
+  const buffer = new Uint8Array(2 * 2 * 4) // RGBA = 4 bytes per pixel
+  await frame.copyTo(buffer)
+
+  // Check first pixel is red (RGBA)
+  t.is(buffer[0], 255, 'R should be 255')
+  t.is(buffer[1], 0, 'G should be 0')
+  t.is(buffer[2], 0, 'B should be 0')
+  t.is(buffer[3], 255, 'A should be 255')
+
+  frame.close()
+})
+
+runTest('VideoFrame: Canvas with drawn graphics', async (t) => {
+  const canvas = createCanvas(100, 100)
+  const ctx = canvas.getContext('2d')
+
+  // Fill with blue background
+  ctx.fillStyle = '#0000FF'
+  ctx.fillRect(0, 0, 100, 100)
+
+  // Draw a white line
+  ctx.strokeStyle = '#FFFFFF'
+  ctx.lineWidth = 2
+  ctx.beginPath()
+  ctx.moveTo(0, 0)
+  ctx.lineTo(100, 100)
+  ctx.stroke()
+
+  const frame = new VideoFrame(canvas, { timestamp: 5000 })
+
+  t.is(frame.format, 'RGBA')
+  t.is(frame.codedWidth, 100)
+  t.is(frame.codedHeight, 100)
+  t.is(frame.timestamp, 5000)
+
+  frame.close()
+})
+
+runTest('VideoFrame: Canvas various sizes', (t) => {
+  const sizes = [
+    [1, 1],
+    [16, 16],
+    [640, 480],
+    [1920, 1080],
+  ] as const
+
+  for (const [width, height] of sizes) {
+    const canvas = createCanvas(width, height)
+
+    const frame = new VideoFrame(canvas, { timestamp: 0 })
+
+    t.is(frame.codedWidth, width, `Width should be ${width}`)
+    t.is(frame.codedHeight, height, `Height should be ${height}`)
+    t.is(frame.format, 'RGBA')
+
+    frame.close()
+  }
+})
+
+runTest('VideoFrame: Canvas sRGB color space default', (t) => {
+  const canvas = createCanvas(100, 100)
+
+  const frame = new VideoFrame(canvas, { timestamp: 0 })
+
+  // Per W3C spec, RGBA defaults to sRGB color space
+  const colorSpace = frame.colorSpace
+  t.is(colorSpace.primaries, 'bt709')
+  t.is(colorSpace.transfer, 'iec61966-2-1') // sRGB
+  t.is(colorSpace.fullRange, true)
+
+  frame.close()
+})
+
+runTest('VideoFrame: Canvas clone preserves data', async (t) => {
+  const canvas = createCanvas(10, 10)
+  const ctx = canvas.getContext('2d')
+
+  // Fill with green
+  ctx.fillStyle = '#00FF00'
+  ctx.fillRect(0, 0, 10, 10)
+
+  const frame1 = new VideoFrame(canvas, { timestamp: 100 })
+  const frame2 = new VideoFrame(frame1, { timestamp: 200 })
+
+  t.is(frame1.timestamp, 100)
+  t.is(frame2.timestamp, 200)
+  t.is(frame1.format, frame2.format)
+  t.is(frame1.codedWidth, frame2.codedWidth)
+  t.is(frame1.codedHeight, frame2.codedHeight)
+
+  // Verify pixel data is the same
+  const buffer1 = new Uint8Array(10 * 10 * 4)
+  const buffer2 = new Uint8Array(10 * 10 * 4)
+  await frame1.copyTo(buffer1)
+  await frame2.copyTo(buffer2)
+
+  t.deepEqual(buffer1, buffer2, 'Cloned frame should have same pixel data')
+
+  frame1.close()
+  frame2.close()
+})
+
+// ============================================================================
+// Integration Tests
+// ============================================================================
+
+runTest('VideoFrame: Canvas can be encoded (smoke test)', async (t) => {
+  // This is a basic smoke test to verify Canvas frames work with encoders
+  // Full encoder tests are in other test files
+  const canvas = createCanvas(320, 240)
+  const ctx = canvas.getContext('2d')
+
+  ctx.fillStyle = '#FF0000'
+  ctx.fillRect(0, 0, 320, 240)
+
+  const chunks: InstanceType<typeof EncodedVideoChunk>[] = []
+  const encoder = new VideoEncoder({
+    output: (chunk) => {
+      chunks.push(chunk)
+    },
+    error: (e) => {
+      t.fail(`Encoder error: ${e.message}`)
+    },
+  })
+
+  encoder.configure({
+    codec: 'vp8',
+    width: 320,
+    height: 240,
+    bitrate: 1_000_000,
+  })
+
+  // Create frame from canvas and encode
+  const frame = new VideoFrame(canvas, { timestamp: 0 })
+  encoder.encode(frame)
+  frame.close()
+
+  await encoder.flush()
+  encoder.close()
+
+  t.true(chunks.length > 0, 'Should have encoded at least one chunk')
+  t.is(chunks[0]!.type, 'key', 'First chunk should be keyframe')
+})

--- a/dts-header.d.ts
+++ b/dts-header.d.ts
@@ -32,3 +32,30 @@ export {
   BufferSource,
   AllowSharedBufferSource,
 } from './standard'
+
+export type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array
+
+/**
+ * Interface for Canvas-like objects compatible with VideoFrame constructor.
+ * Compatible with @napi-rs/canvas Canvas class.
+ *
+ * @napi-rs/canvas is an optional peer dependency. If installed, Canvas objects
+ * can be used as VideoFrame sources. The Canvas pixel data is copied (RGBA format).
+ */
+export interface CanvasLike {
+  readonly width: number
+  readonly height: number
+  /** Returns raw RGBA pixel data as a Buffer */
+  data(): Uint8Array
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,33 @@ export type TypedArray =
   | Float64Array
   | BigInt64Array
   | BigUint64Array
+
+/**
+ * Interface for Canvas-like objects compatible with VideoFrame constructor.
+ * Compatible with @napi-rs/canvas Canvas class.
+ *
+ * @napi-rs/canvas is an optional peer dependency. If installed, Canvas objects
+ * can be used as VideoFrame sources. The Canvas pixel data is copied (RGBA format).
+ */
+export interface CanvasLike {
+  readonly width: number
+  readonly height: number
+  /** Returns raw RGBA pixel data as a Buffer */
+  data(): Uint8Array
+}
+
+export type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array
 /**
  * AudioData - represents uncompressed audio data
  *
@@ -668,13 +695,14 @@ export declare class VideoEncoder {
  */
 export declare class VideoFrame {
   /**
-   * Create a new VideoFrame from buffer data or another VideoFrame (W3C WebCodecs spec)
+   * Create a new VideoFrame from buffer data, another VideoFrame, or a Canvas (W3C WebCodecs spec)
    *
-   * Two constructor forms per W3C spec:
+   * Constructor forms per W3C spec:
    * 1. `new VideoFrame(data, init)` - from BufferSource with VideoFrameBufferInit
    * 2. `new VideoFrame(source, init?)` - from another VideoFrame with optional VideoFrameInit
+   * 3. `new VideoFrame(canvas, init)` - from @napi-rs/canvas Canvas (requires timestamp in init)
    */
-  constructor(source: VideoFrame | Uint8Array, init?: VideoFrameBufferInit | VideoFrameInit)
+  constructor(source: VideoFrame | Uint8Array | CanvasLike, init?: VideoFrameBufferInit | VideoFrameInit)
   /** Get the pixel format */
   get format(): VideoPixelFormat | null
   /** Get the coded width in pixels (returns 0 when closed per W3C spec) */

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@emnapi/core": "^1.7.1",
     "@emnapi/runtime": "^1.7.1",
+    "@napi-rs/canvas": "^0.1.84",
     "@napi-rs/cli": "^3.5.0",
     "@napi-rs/wasm-runtime": "^1.1.0",
     "@oxc-node/core": "^0.0.35",
@@ -91,6 +92,14 @@
     "prettier": "^3.7.4",
     "tinybench": "^6.0.0",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@napi-rs/canvas": ">=0.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@napi-rs/canvas": {
+      "optional": true
+    }
   },
   "napi": {
     "binaryName": "webcodecs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@emnapi/runtime':
         specifier: ^1.7.1
         version: 1.7.1
+      '@napi-rs/canvas':
+        specifier: ^0.1.84
+        version: 0.1.84
       '@napi-rs/cli':
         specifier: ^3.5.0
         version: 3.5.0(@emnapi/runtime@1.7.1)(@types/node@25.0.2)
@@ -229,6 +232,70 @@ packages:
     resolution: {integrity: sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@napi-rs/canvas-android-arm64@0.1.84':
+    resolution: {integrity: sha512-pdvuqvj3qtwVryqgpAGornJLV6Ezpk39V6wT4JCnRVGy8I3Tk1au8qOalFGrx/r0Ig87hWslysPpHBxVpBMIww==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.84':
+    resolution: {integrity: sha512-A8IND3Hnv0R6abc6qCcCaOCujTLMmGxtucMTZ5vbQUrEN/scxi378MyTLtyWg+MRr6bwQJ6v/orqMS9datIcww==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.84':
+    resolution: {integrity: sha512-AUW45lJhYWwnA74LaNeqhvqYKK/2hNnBBBl03KRdqeCD4tKneUSrxUqIv8d22CBweOvrAASyKN3W87WO2zEr/A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.84':
+    resolution: {integrity: sha512-8zs5ZqOrdgs4FioTxSBrkl/wHZB56bJNBqaIsfPL4ZkEQCinOkrFF7xIcXiHiKp93J3wUtbIzeVrhTIaWwqk+A==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.84':
+    resolution: {integrity: sha512-i204vtowOglJUpbAFWU5mqsJgH0lVpNk/Ml4mQtB4Lndd86oF+Otr6Mr5KQnZHqYGhlSIKiU2SYnUbhO28zGQA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.84':
+    resolution: {integrity: sha512-VyZq0EEw+OILnWk7G3ZgLLPaz1ERaPP++jLjeyLMbFOF+Tr4zHzWKiKDsEV/cT7btLPZbVoR3VX+T9/QubnURQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.84':
+    resolution: {integrity: sha512-PSMTh8DiThvLRsbtc/a065I/ceZk17EXAATv9uNvHgkgo7wdEfTh2C3aveNkBMGByVO3tvnvD5v/YFtZL07cIg==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.84':
+    resolution: {integrity: sha512-N1GY3noO1oqgEo3rYQIwY44kfM11vA0lDbN0orTOHfCSUZTUyiYCY0nZ197QMahZBm1aR/vYgsWpV74MMMDuNA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.84':
+    resolution: {integrity: sha512-vUZmua6ADqTWyHyei81aXIt9wp0yjeNwTH0KdhdeoBb6azHmFR8uKTukZMXfLCC3bnsW0t4lW7K78KNMknmtjg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.84':
+    resolution: {integrity: sha512-YSs8ncurc1xzegUMNnQUTYrdrAuaXdPMOa+iYYyAxydOtg0ppV386hyYMsy00Yip1NlTgLCseRG4sHSnjQx6og==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.84':
+    resolution: {integrity: sha512-88FTNFs4uuiFKP0tUrPsEXhpe9dg7za9ILZJE08pGdUveMIDeana1zwfVkqRHJDPJFAmGY3dXmJ99dzsy57YnA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/cli@3.5.0':
     resolution: {integrity: sha512-bJsDvAa9qK9VMkFhr780XWfQlK+GDlAX8qpK20buSmA0ld6nxCtiZ5a0J45zbd0FWT+VTZE1/u8VPH2vLfnVvw==}
@@ -1869,6 +1936,49 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@napi-rs/canvas-android-arm64@0.1.84':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.84':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.84':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.84':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.84':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.84':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.84':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.84':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.84':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.84':
+    optional: true
+
+  '@napi-rs/canvas@0.1.84':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.84
+      '@napi-rs/canvas-darwin-arm64': 0.1.84
+      '@napi-rs/canvas-darwin-x64': 0.1.84
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.84
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.84
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.84
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.84
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.84
+      '@napi-rs/canvas-linux-x64-musl': 0.1.84
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.84
 
   '@napi-rs/cli@3.5.0(@emnapi/runtime@1.7.1)(@types/node@25.0.2)':
     dependencies:


### PR DESCRIPTION
Add support for creating VideoFrame from @napi-rs/canvas Canvas objects
per W3C WebCodecs spec for CanvasImageSource.

Changes:
- Add Canvas detection in VideoFrame constructor using duck-typing
- Add new_from_canvas() method that extracts RGBA pixel data
- Add CanvasLike interface to TypeScript definitions
- Add @napi-rs/canvas as optional peer dependency
- Add comprehensive test suite for Canvas integration

The Canvas.data() method is called with proper 'this' binding using
low-level napi to avoid "Illegal invocation" errors. Pixel data is
extracted as RGBA format with sRGB color space default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>