### PR TITLE
refactor: unify frame sharing with Rust Arc, remove FFmpeg ref counting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ thiserror = "2"
 # Concurrent data structures
 crossbeam = "0.8"
 
+# Better RwLock implementation (no poisoning, better perf)
+parking_lot = "0.12"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = [

--- a/index.d.ts
+++ b/index.d.ts
@@ -1079,7 +1079,12 @@ export declare class VideoFrame {
    * Options can specify target format and rect for cropped copy.
    */
   copyTo(destination: Uint8Array, options?: VideoFrameCopyToOptions | undefined | null): Promise<Array<PlaneLayout>>
-  /** Clone this VideoFrame */
+  /**
+   * Clone this VideoFrame
+   *
+   * This creates a new VideoFrame that shares the underlying pixel data with the original.
+   * Both frames will reference the same Arc<RwLock<Frame>>, so no pixel data is copied.
+   */
   clone(): VideoFrame
   /**
    * Close and release resources

--- a/src/codec/packet.rs
+++ b/src/codec/packet.rs
@@ -11,7 +11,7 @@ use crate::ffi::{
   },
   avcodec::{
     av_new_packet, av_packet_alloc, av_packet_free, av_packet_get_side_data,
-    av_packet_new_side_data, av_packet_ref, av_packet_unref,
+    av_packet_new_side_data, av_packet_unref,
   },
   pkt_flag, pkt_side_data_type,
 };
@@ -228,14 +228,6 @@ impl Packet {
     unsafe { av_packet_unref(self.as_mut_ptr()) }
   }
 
-  /// Create a new reference to this packet's data
-  pub fn try_clone(&self) -> Result<Self, CodecError> {
-    let new_pkt = Self::new()?;
-    let ret = unsafe { av_packet_ref(new_pkt.ptr.as_ptr(), self.as_ptr()) };
-    ffi::check_error(ret)?;
-    Ok(new_pkt)
-  }
-
   /// Copy packet data to a new Vec
   pub fn to_vec(&self) -> Vec<u8> {
     self.as_slice().to_vec()
@@ -288,12 +280,6 @@ impl std::fmt::Debug for Packet {
       .field("dts", &self.dts())
       .field("is_key", &self.is_key())
       .finish()
-  }
-}
-
-impl Clone for Packet {
-  fn clone(&self) -> Self {
-    self.try_clone().expect("Failed to clone packet")
   }
 }
 

--- a/src/webcodecs/audio_encoder.rs
+++ b/src/webcodecs/audio_encoder.rs
@@ -1523,11 +1523,11 @@ impl AudioEncoder {
         }
       }
 
-      // Get frame from AudioData
-      let frame = match data.with_frame(|f| f.try_clone()) {
+      // Get frame from AudioData (deep copy for encoder mutation)
+      let frame = match data.with_frame(|f| f.deep_clone()) {
         Ok(Ok(f)) => f,
         Ok(Err(e)) => {
-          Self::report_error(&mut inner, &format!("Failed to clone frame: {}", e));
+          Self::report_error(&mut inner, &format!("Failed to copy frame: {}", e));
           return Ok(());
         }
         Err(e) => {


### PR DESCRIPTION
Replace FFmpeg's internal reference counting (av_frame_clone) with Rust's Arc<RwLock<Frame>> for sharing frame data. This eliminates dual reference counting and provides a single source of truth.

Key changes:
- Add parking_lot dependency for better RwLock performance
- Frame: remove try_clone(), add deep_clone() and into_shared()
- Packet: remove try_clone() (0 callers)
- VideoFrameInner/AudioDataInner: use Arc<RwLock<Frame>>
- VideoEncoder/AudioEncoder: share frames via Arc, deep_clone when mutation needed
- ImageDecoder: cache frames as Arc for efficient multi-access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies frame ownership by replacing FFmpeg ref-counted clones with Rust `Arc<RwLock<Frame>>`, reducing copies and centralizing synchronization.
> 
> - Add `parking_lot` and introduce `Frame::deep_clone()` and `Frame::into_shared()`; remove `try_clone()` usage throughout
> - Migrate `AudioData`/`VideoFrame` internals to `Arc<RwLock<Frame>>`; `VideoFrame.clone()` now shares backing data; expose `frame_arc()` and add `from_internal_arc(_with_color_space)`
> - Update `VideoEncoder`/`AudioEncoder` to accept/share frames via `Arc` and only `deep_clone()` when mutation or upload requires ownership; adjust scaling/copy paths to use read locks
> - `ImageDecoder` caches decoded frames as shared `Arc` frames and returns `VideoFrame` via shared constructors
> - Remove `Packet::try_clone()` and `Clone` impl (no callers)
> - Type definitions: document `VideoFrame.clone()` sharing semantics in `index.d.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 720f0c400451dff5a745d5dc0ef137602aa57a9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->