### PR TITLE
perf: reduce data copies in encode/decode/mux pipeline

### DIFF
--- a/src/webcodecs/demuxer_base.rs
+++ b/src/webcodecs/demuxer_base.rs
@@ -443,7 +443,7 @@ impl<F: DemuxerFormat> DemuxerInner<F> {
               chunk_type,
               timestamp,
               duration,
-              data: packet.to_vec(),
+              data: Either::B(packet),
             };
 
             match EncodedVideoChunk::new(init) {
@@ -477,7 +477,7 @@ impl<F: DemuxerFormat> DemuxerInner<F> {
               chunk_type: EncodedAudioChunkType::Key, // Audio packets are typically keyframes
               timestamp,
               duration,
-              data: packet.to_vec(),
+              data: Either::B(packet),
             };
 
             match EncodedAudioChunk::new(init) {


### PR DESCRIPTION
Zero-copy optimizations using FFmpeg's atomic reference-counted buffers:

Frame handling:
- Add Frame::shallow_clone() using av_frame_ref() for video encoder
- Replace deep_clone() with shallow_clone() in AudioEncoder (no resampling case)
- Use shallow_clone() for HW encoder fallback frame buffering

Packet handling:
- Add Packet::shallow_clone() using av_packet_ref()
- Store Packet directly in EncodedVideoChunk/EncodedAudioChunk via Either<Vec<u8>, Packet>
- Demuxer passes packets directly without to_vec() copy
- Muxer uses get_packet_for_muxing() with shallow_clone when chunk has Packet

Decoder optimizations:
- VideoDecoder uses Cow<[u8]> for AVCC→AnnexB conversion (skip copy for VP8/VP9/AV1)
- AudioDecoder passes Arc<RwLock<EncodedAudioChunkInner>> instead of extracting Vec<u8>
- Change callbacks from Blocking to NonBlocking mode

Input parsing:
- EncodedAudioChunk: use Uint8ArraySlice for single-copy DataView handling
- EncodedVideoChunk: use slice-based access instead of double-copy

Safety:
- Add comprehensive SAFETY comments for unsafe Send/Sync impls
- Document FFmpeg AVBufferRef atomic refcounting guarantees
- Move EncodedVideoChunkInner Send/Sync impls to correct file

Performance impact:
- Encoder→Muxer: ~100 bytes copied instead of 100KB-1MB per chunk
- Frame prep: shallow clone instead of 3-12MB deep copy per frame
- DataView input: 1 copy instead of 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major zero-copy pipeline optimizations leveraging FFmpeg refcounted buffers.
> 
> - Add `Frame::shallow_clone()` and `Packet::shallow_clone()` (via `av_frame_ref`/`av_packet_ref`) to share buffers without copying
> - Store `Either<Vec<u8>, Packet>` in `EncodedVideoChunk`/`EncodedAudioChunk`; demuxer populates chunks with `Packet` and muxer pulls via `get_packet_for_muxing()` (shallow clone when possible)
> - Video/Audio encoders: use `shallow_clone()` instead of deep copies for non-conversion paths and HW fallback buffering
> - Decoders: avoid unnecessary copies (`Cow<[u8]>` for AVCC→AnnexB; AudioDecoder passes `Arc<RwLock<EncodedAudioChunkInner>>` and decodes from slice/packet)
> - Input parsing: use slice-based reads and `Uint8ArraySlice` to avoid double-copy for BufferSource/DataView
> - Event delivery: change multiple TSF calls from Blocking to NonBlocking to avoid worker stalls
> - Safety: add `Send`/`Sync` impls and detailed comments documenting AVBufferRef atomic refcounting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78bb9c14a2f82bd8897d9d724e37bce7fa8b3719. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->