### PR TITLE
feat(demuxer): add async iteration and demuxAsync method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,8 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-# NAPI-RS bindings
-napi = { version = "3", features = ["async", "napi4", "web_stream"] }
-napi-derive = "3"
+napi = { version = "3", features = ["async", "napi5", "web_stream"] }
+napi-derive = { version = "3" }
 
 futures = "0.3"
 

--- a/benchmark/bench-napi.ts
+++ b/benchmark/bench-napi.ts
@@ -43,19 +43,11 @@ const demuxer = new NapiWebCodecs.Mp4Demuxer({
 
 await demuxer.loadBuffer(videoData)
 
-// Wait until ready
-while (demuxer.state === 'unloaded') {
-  await new Promise((r) => setTimeout(r, 10))
-}
-
 videoConfig = demuxer.videoDecoderConfig
 results.resolution = `${videoConfig.codedWidth}x${videoConfig.codedHeight}`
 
-// Demux all packets
-while (demuxer.state !== 'ended' && demuxer.state !== 'closed') {
-  demuxer.demux(100)
-  await new Promise((r) => setTimeout(r, 1))
-}
+// Demux all packets using async API
+await demuxer.demuxAsync()
 demuxer.close()
 
 results.totalFrames = chunks.length

--- a/benchmark/bench-polyfill.ts
+++ b/benchmark/bench-polyfill.ts
@@ -47,18 +47,11 @@ const demuxer = new NapiWebCodecs.Mp4Demuxer({
 
 await demuxer.loadBuffer(videoData)
 
-// Wait until ready
-while (demuxer.state === 'unloaded') {
-  await new Promise((r) => setTimeout(r, 10))
-}
-
 videoConfig = demuxer.videoDecoderConfig
 results.resolution = `${videoConfig.codedWidth}x${videoConfig.codedHeight}`
 
-while (demuxer.state !== 'ended' && demuxer.state !== 'closed') {
-  demuxer.demux(100)
-  await new Promise((r) => setTimeout(r, 1))
-}
+// Demux all packets using async API
+await demuxer.demuxAsync()
 demuxer.close()
 
 results.totalFrames = chunks.length

--- a/dts-header.d.ts
+++ b/dts-header.d.ts
@@ -136,3 +136,57 @@ export interface MkvMuxerInit {
   /** Enable streaming output mode */
   streaming?: { bufferCapacity?: number }
 }
+
+// ============================================================================
+// Async Iterator Types
+// ============================================================================
+
+/**
+ * Chunk yielded by demuxer async iterator.
+ *
+ * Contains either a video or audio chunk. Use the `chunkType` property
+ * to determine which type of chunk is present.
+ *
+ * @example
+ * ```typescript
+ * for await (const chunk of demuxer) {
+ *   if (chunk.chunkType === 'video') {
+ *     videoDecoder.decode(chunk.videoChunk!)
+ *   } else {
+ *     audioDecoder.decode(chunk.audioChunk!)
+ *   }
+ * }
+ * ```
+ */
+export interface DemuxerChunk {
+  /** Type of chunk: 'video' or 'audio' */
+  chunkType: 'video' | 'audio'
+  /** Video chunk (present when chunkType is 'video') */
+  videoChunk?: EncodedVideoChunk
+  /** Audio chunk (present when chunkType is 'audio') */
+  audioChunk?: EncodedAudioChunk
+}
+
+/**
+ * Adds async iterator support to Mp4Demuxer.
+ * Declaration merging allows using `for await...of` with the demuxer.
+ */
+export interface Mp4Demuxer {
+  [Symbol.asyncIterator](): AsyncGenerator<DemuxerChunk, void, void>
+}
+
+/**
+ * Adds async iterator support to WebMDemuxer.
+ * Declaration merging allows using `for await...of` with the demuxer.
+ */
+export interface WebMDemuxer {
+  [Symbol.asyncIterator](): AsyncGenerator<DemuxerChunk, void, void>
+}
+
+/**
+ * Adds async iterator support to MkvDemuxer.
+ * Declaration merging allows using `for await...of` with the demuxer.
+ */
+export interface MkvDemuxer {
+  [Symbol.asyncIterator](): AsyncGenerator<DemuxerChunk, void, void>
+}

--- a/src/webcodecs/mod.rs
+++ b/src/webcodecs/mod.rs
@@ -72,7 +72,9 @@ pub use video_frame::{
 };
 pub use webm_muxer::{WebMAudioTrackConfig, WebMMuxer, WebMMuxerOptions, WebMVideoTrackConfig};
 // Demuxer types
-pub use demuxer_base::{DemuxerAudioDecoderConfig, DemuxerTrackInfo, DemuxerVideoDecoderConfig};
+pub use demuxer_base::{
+  DemuxerAudioDecoderConfig, DemuxerChunk, DemuxerTrackInfo, DemuxerVideoDecoderConfig,
+};
 pub use mkv_demuxer::{MkvDemuxer, MkvDemuxerInit};
 pub use mp4_demuxer::{Mp4Demuxer, Mp4DemuxerInit};
 pub use muxer_base::StreamingMuxerOptions;

--- a/src/webcodecs/webm_demuxer.rs
+++ b/src/webcodecs/webm_demuxer.rs
@@ -5,9 +5,9 @@
 
 use crate::ffi::AVCodecID;
 use crate::webcodecs::demuxer_base::{
-  AudioOutputCallback, DemuxerAudioDecoderConfig, DemuxerFormat, DemuxerInner, DemuxerTrackInfo,
-  DemuxerVideoDecoderConfig, ErrorCallback, VideoOutputCallback, parse_vp9_codec_string,
-  with_demuxer_inner, with_demuxer_inner_mut,
+  AudioOutputCallback, DemuxerAudioDecoderConfig, DemuxerChunk, DemuxerFormat, DemuxerInner,
+  DemuxerTrackInfo, DemuxerVideoDecoderConfig, ErrorCallback, VideoOutputCallback,
+  parse_vp9_codec_string, with_demuxer_inner, with_demuxer_inner_mut,
 };
 use crate::webcodecs::encoded_audio_chunk::EncodedAudioChunk;
 use crate::webcodecs::encoded_video_chunk::EncodedVideoChunk;
@@ -119,9 +119,33 @@ impl FromNapiValue for WebMDemuxerInit {
 /// WebM Demuxer for reading encoded video and audio from WebM container
 ///
 /// WebM typically contains VP8, VP9, or AV1 video with Opus or Vorbis audio.
-#[napi]
+#[napi(async_iterator)]
 pub struct WebMDemuxer {
   inner: Arc<Mutex<DemuxerInner<WebMFormat>>>,
+}
+
+impl AsyncGenerator for WebMDemuxer {
+  type Yield = DemuxerChunk;
+  type Next = ();
+  type Return = ();
+
+  fn next(
+    &mut self,
+    _value: Option<Self::Next>,
+  ) -> impl std::future::Future<Output = Result<Option<Self::Yield>>> + Send + 'static {
+    let inner = self.inner.clone();
+
+    async move {
+      tokio::task::spawn_blocking(move || {
+        let mut guard = inner
+          .lock()
+          .map_err(|_| Error::new(Status::GenericFailure, "Lock poisoned"))?;
+        guard.read_next_chunk()
+      })
+      .await
+      .map_err(|e| Error::new(Status::GenericFailure, format!("Task error: {}", e)))?
+    }
+  }
 }
 
 #[napi]
@@ -220,6 +244,23 @@ impl WebMDemuxer {
     });
 
     Ok(())
+  }
+
+  /// Demux packets asynchronously (awaitable version of demux)
+  #[napi]
+  pub async fn demux_async(&self, count: Option<u32>) -> Result<()> {
+    let inner = self.inner.clone();
+    let max_packets = count.unwrap_or(u32::MAX);
+
+    tokio::task::spawn_blocking(move || {
+      let mut guard = inner
+        .lock()
+        .map_err(|_| Error::new(Status::GenericFailure, "Lock poisoned"))?;
+      guard.demux_sync(max_packets);
+      Ok(())
+    })
+    .await
+    .map_err(|e| Error::new(Status::GenericFailure, format!("Task error: {}", e)))?
   }
 
   #[napi]


### PR DESCRIPTION
Add `for await...of` loop support and `demuxAsync()` method to all demuxers (Mp4Demuxer, WebMDemuxer, MkvDemuxer).

Changes:
- Implement `AsyncGenerator` trait via NAPI-RS for all demuxers
- Add `read_next_chunk()` method for single-packet reading
- Add `demuxAsync()` as awaitable alternative to sync `demux()`
- Add `DemuxerChunk` type with discriminated union pattern
- Update TypeScript types with declaration merging for Symbol.asyncIterator
- Add 10 tests covering async iteration and demuxAsync

The async iterator provides a cleaner streaming API:
```js
  for await (const chunk of demuxer) {
    if (chunk.chunkType === 'video') {
      videoDecoder.decode(chunk.videoChunk!)
    }
  }
```

The `demuxAsync()` method eliminates the polling pattern:
```js
  // Before
  while (demuxer.state !== 'ended') {
    demuxer.demux(100)
    await new Promise(r => setTimeout(r, 1))
  }
```
After
```js
  await demuxer.demuxAsync()
```
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an async, stream-friendly demuxing API and awaitable demux calls.
> 
> - **Async iteration:** Implemented `[Symbol.asyncIterator]` on `Mp4Demuxer`, `WebMDemuxer`, `MkvDemuxer` via `#[napi(async_iterator)]`, yielding `DemuxerChunk` from new `DemuxerInner::read_next_chunk()`
> - **Awaitable demux:** Added `demuxAsync(count?)` to all demuxers (awaitable version of `demux()`)
> - **TypeScript updates:** Declared `DemuxerChunk` and iterator signatures; enhanced JSDoc on demuxers in `index.d.ts`/`dts-header.d.ts`
> - **Benchmarks:** Replaced polling loops with `await demuxer.demuxAsync()`
> - **Tests:** Added async iterator and `demuxAsync` coverage for MP4/WebM/MKV, including audio+video paths
> - **Build:** Bumped `napi` feature to `napi5` in `Cargo.toml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c18171e7104844b858e073cff62adb99cee2434. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->