### PR TITLE
test: fix flaky

### DIFF
--- a/__test__/wpt/full-cycle-test.spec.ts
+++ b/__test__/wpt/full-cycle-test.spec.ts
@@ -188,6 +188,13 @@ async function runFullCycleTest(
   await encoder.flush()
   await decoder.flush()
 
+  // Yield to event loop to let any pending NonBlocking callbacks complete.
+  // Decoder output callbacks use NonBlocking mode (ThreadsafeFunction) which
+  // schedules callbacks in libuv's Poll phase. The flush promise resolves in
+  // the microtask phase, so we need setImmediate (Check phase) to ensure all
+  // pending frame callbacks have run before asserting.
+  await new Promise((resolve) => setImmediate(resolve))
+
   encoder.close()
   decoder.close()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Stabilizes WPT full-cycle test timing**
> 
> - After `encoder.flush()` and `decoder.flush()`, adds `await new Promise((r) => setImmediate(r))` to let NonBlocking decoder output callbacks (scheduled in libuv's Poll phase) run before assertions. Ensures all frame callbacks complete, preventing intermittent failures.
> - Change is limited to `__test__/wpt/full-cycle-test.spec.ts`; no production code modifications.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a14c432c48a8184a31408bf83348f39f0ebaffd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->