### PR TITLE
build: upgrade FFmpeg to 9.0

### DIFF
--- a/.github/workflows/ffmpeg-build.yml
+++ b/.github/workflows/ffmpeg-build.yml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
     inputs:
       ffmpeg_version:
-        description: 'FFmpeg version tag (e.g., n8.0.1)'
+        description: 'FFmpeg version tag (e.g., n9.0)'
         required: true
-        default: 'n8.0.1'
+        default: 'n9.0'
 
 env:
-  FFMPEG_VERSION: ${{ github.event.inputs.ffmpeg_version || 'n8.0.1' }}
+  FFMPEG_VERSION: ${{ github.event.inputs.ffmpeg_version || 'n9.0' }}
 
 jobs:
   # Build for x86_64 and aarch64 targets using zig
@@ -54,6 +54,7 @@ jobs:
         run: |
           cargo build --release -p build-ffmpeg
           ./target/release/build-ffmpeg \
+            --ffmpeg-version "$FFMPEG_VERSION" \
             --target ${{ matrix.target }} \
             --output ./ffmpeg-${{ matrix.target }} \
             --verbose
@@ -244,7 +245,7 @@ jobs:
 
       - name: Clone FFmpeg
         run: |
-          git clone --depth=1 -b ${{ env.FFMPEG_VERSION }} https://github.com/FFmpeg/FFmpeg.git ffmpeg-src
+          git clone --depth=1 -b "$env:FFMPEG_VERSION" https://github.com/FFmpeg/FFmpeg.git ffmpeg-src
 
       - name: Build FFmpeg with MSVC toolchain
         shell: msys2 {0}
@@ -670,7 +671,7 @@ jobs:
 
       - name: Clone FFmpeg
         run: |
-          git clone --depth=1 -b ${{ env.FFMPEG_VERSION }} https://github.com/FFmpeg/FFmpeg.git ffmpeg-src
+          git clone --depth=1 -b "$env:FFMPEG_VERSION" https://github.com/FFmpeg/FFmpeg.git ffmpeg-src
 
       - name: Build FFmpeg with MSVC toolchain
         shell: msys2 {0}
@@ -1015,6 +1016,7 @@ jobs:
           export CXXFLAGS="-march=armv7-a -mfpu=neon -mfloat-abi=hard"
           cargo build --release -p build-ffmpeg
           ./target/release/build-ffmpeg \
+            --ffmpeg-version "$FFMPEG_VERSION" \
             --target armv7-unknown-linux-gnueabihf \
             --output ./ffmpeg-armv7-unknown-linux-gnueabihf \
             --use-system-cc \
@@ -1075,6 +1077,7 @@ jobs:
         run: |
           cargo build --release -p build-ffmpeg
           ./target/release/build-ffmpeg \
+            --ffmpeg-version "$FFMPEG_VERSION" \
             --target x86_64-apple-darwin \
             --output ./ffmpeg-x86_64-apple-darwin \
             --use-system-cc \
@@ -1132,6 +1135,7 @@ jobs:
         run: |
           cargo build --release -p build-ffmpeg
           ./target/release/build-ffmpeg \
+            --ffmpeg-version "$FFMPEG_VERSION" \
             --target aarch64-apple-darwin \
             --output ./ffmpeg-aarch64-apple-darwin \
             --use-system-cc \

--- a/.github/workflows/ffmpeg-build.yml
+++ b/.github/workflows/ffmpeg-build.yml
@@ -502,7 +502,8 @@ jobs:
   # Build Windows x64 from source with rav1e (libaom crashes on Windows MSVC)
   build-ffmpeg-windows-x64:
     name: Build x86_64-pc-windows-msvc
-    runs-on: windows-latest
+    # x265's multi-lib build uses the Visual Studio 17 2022 CMake generator.
+    runs-on: windows-2022
     permissions:
       id-token: write
       attestations: write

--- a/.github/workflows/ffmpeg-build.yml
+++ b/.github/workflows/ffmpeg-build.yml
@@ -1186,6 +1186,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ffmpeg-${{ env.FFMPEG_VERSION }}
+          target_commitish: ${{ github.sha }}
           name: FFmpeg ${{ env.FFMPEG_VERSION }} Static Builds
           body: |
             Pre-built FFmpeg ${{ env.FFMPEG_VERSION }} static libraries.

--- a/README.md
+++ b/README.md
@@ -695,9 +695,9 @@ For full API documentation, see the [W3C WebCodecs specification](https://w3c.gi
 - Node.js 18+
 - pnpm
 
-The build downloads the pinned FFmpeg 8.0.1 release by default. If you opt out
+The build downloads the pinned FFmpeg 9.0 release by default. If you opt out
 of that download or set `FFMPEG_DIR`, the supplied FFmpeg headers and libraries
-must be from FFmpeg 8.x; FFmpeg 7.x system/Homebrew installations are rejected
+must be from FFmpeg 9.x; FFmpeg 8.x system/Homebrew installations are rejected
 by the ABI guard.
 
 ### Build

--- a/build.rs
+++ b/build.rs
@@ -17,47 +17,47 @@ use sha2::{Digest, Sha256};
 /// The Rust FFI constants and C accessors are validated against this FFmpeg
 /// release. `FFMPEG_RELEASE_TAG` remains an explicit escape hatch for
 /// maintainers testing a deliberate upgrade.
-const DEFAULT_FFMPEG_RELEASE_TAG: &str = "ffmpeg-n8.0.1";
+const DEFAULT_FFMPEG_RELEASE_TAG: &str = "ffmpeg-n9.0";
 const DEFAULT_FFMPEG_GITHUB_REPO: &str = "Brooooooklyn/webcodecs-node";
 
-/// SHA-256 digests published by GitHub for the pinned ffmpeg-n8.0.1 assets.
+/// SHA-256 digests published by GitHub for the pinned ffmpeg-n9.0 assets.
 /// A release/tag upgrade must update these values in the same change.
 const DEFAULT_FFMPEG_ARCHIVE_SHA256: &[(&str, &str)] = &[
   (
     "ffmpeg-aarch64-apple-darwin.tar.gz",
-    "ef26bdc401c86cbca70d26fdbe6f105c7c113b2d82f944818cfc4f7e53028f2a",
+    "3bddf95511e108ba204abfd0ce68b8e6423c7d5122a25152201ee60530cb4cc8",
   ),
   (
     "ffmpeg-aarch64-pc-windows-msvc.zip",
-    "041e1597f0044213d650713def40e95ad056831745b192948ce54edfd6f883d7",
+    "3ba0fd4f88f572bb8d792fbca8ac15625ac92412b9fc5448f77041252f885b36",
   ),
   (
     "ffmpeg-aarch64-unknown-linux-gnu.tar.gz",
-    "f1dc3135a93bdf77e335eed97cacfe8f6b59bc519cf26ab387352af7e17d72cc",
+    "8407fd0157fd559e062dd339167650bb541a6a43ddfb6d9a38b81691f3f931f0",
   ),
   (
     "ffmpeg-aarch64-unknown-linux-musl.tar.gz",
-    "92c866ef4ca371e7ad3e535c165bed015c354129a96f46a359cd94e0805e1fb0",
+    "4e7638aff618adbcea9a16dfb75d1372d86747fc417428b13c09805b35f0feea",
   ),
   (
     "ffmpeg-armv7-unknown-linux-gnueabihf.tar.gz",
-    "251f0da8509e3619861c9361d521dde03b13bb39aa3be3f7d7f921c7a91fd55e",
+    "4c56ab8bf74a84037316b291db88c69f88cade2cc9fc431fa1a685dc1fb4c8f3",
   ),
   (
     "ffmpeg-x86_64-apple-darwin.tar.gz",
-    "e9c827e33490f11647f2134366e3f2ffa0b339b32fde68dfbd81215ff20c6762",
+    "2b455254194790c36cb3e7271fb4c4ed25b333afdcc3f2606097a67720b19d82",
   ),
   (
     "ffmpeg-x86_64-pc-windows-msvc.zip",
-    "9d50047fec0bcabc778101cef9a040796ba53d2fc4a98f10a07832c01a63652c",
+    "548c0b4aac8edc8119fc50af4bbd3a55dfe0d6750df30a784e84f0f87d925129",
   ),
   (
     "ffmpeg-x86_64-unknown-linux-gnu.tar.gz",
-    "09296b012887001d6a9f962ee3d2ee2e6d28c8adf54c6e2f2c441f01a24c36ed",
+    "b1d609cda08e946d555bf60d1ffb18828b8ef0030018bdb7255b7814b000cf85",
   ),
   (
     "ffmpeg-x86_64-unknown-linux-musl.tar.gz",
-    "da90b04a46a9bb41cc4db54849c6df9801d1ef34798754fec8053adc1b9fe868",
+    "11e1fc40efdd112409622d297c8a16e07940fc2c86cc8c476cebdd3c8673e5e4",
   ),
 ];
 

--- a/src/codec/context.rs
+++ b/src/codec/context.rs
@@ -48,7 +48,7 @@ pub struct DecoderCreationResult {
   /// Whether the decoder uses hardware acceleration
   pub is_hardware: bool,
   /// Hardware pixel format as raw FFmpeg value if using hardware decoding
-  /// This is the raw AV_PIX_FMT_* value (e.g., 157 for VideoToolbox in FFmpeg 8.x)
+  /// This is the raw AV_PIX_FMT_* value (e.g., 157 for VideoToolbox in FFmpeg 9.x)
   pub hw_pix_fmt_raw: Option<i32>,
 }
 

--- a/src/ffi/accessors.c
+++ b/src/ffi/accessors.c
@@ -14,8 +14,8 @@
 #include <libavutil/samplefmt.h>
 #include <libavformat/avformat.h>
 
-#if LIBAVCODEC_VERSION_MAJOR != 62 || LIBAVUTIL_VERSION_MAJOR != 60 || LIBAVFORMAT_VERSION_MAJOR != 62
-#error "Unsupported FFmpeg headers: webcodecs-node is pinned to FFmpeg 8.x (libavcodec 62, libavutil 60, libavformat 62)"
+#if LIBAVCODEC_VERSION_MAJOR != 63 || LIBAVUTIL_VERSION_MAJOR != 61 || LIBAVFORMAT_VERSION_MAJOR != 63
+#error "Unsupported FFmpeg headers: webcodecs-node is pinned to FFmpeg 9.x (libavcodec 63, libavutil 61, libavformat 63)"
 #endif
 
 /* ============================================================================

--- a/src/ffi/types.rs
+++ b/src/ffi/types.rs
@@ -56,12 +56,12 @@ pub enum AVCodecID {
   Bmp = 78, // BMP image
   Gif = 97, // GIF image
   Vp8 = 139,
-  Vp9 = 167,
-  Webp = 171, // WebP image
-  Hevc = 173, // H.265
-  Av1 = 225,
-  Jpegxl = 258,
-  JpegxlAnim = 272,
+  Vp9 = 166,
+  Webp = 170, // WebP image
+  Hevc = 172, // H.265
+  Av1 = 222,
+  Jpegxl = 255,
+  JpegxlAnim = 269,
   // Audio codecs (starting at 0x10000 = 65536)
   PcmS16le = 65536, // PCM signed 16-bit little-endian
   PcmS16be = 65537, // PCM signed 16-bit big-endian
@@ -70,13 +70,13 @@ pub enum AVCodecID {
   PcmS8 = 65540,    // PCM signed 8-bit
   PcmU8 = 65541,    // PCM unsigned 8-bit
   PcmF32le = 65557, // PCM 32-bit float little-endian
-  PcmF32be = 65558, // PCM 32-bit float big-endian
+  PcmF32be = 65556, // PCM 32-bit float big-endian
   PcmF64le = 65559, // PCM 64-bit double little-endian
-  PcmF64be = 65560, // PCM 64-bit double big-endian
+  PcmF64be = 65558, // PCM 64-bit double big-endian
   PcmS32le = 65544, // PCM signed 32-bit little-endian
   PcmS32be = 65545, // PCM signed 32-bit big-endian
-  PcmS24le = 65566, // PCM signed 24-bit little-endian
-  PcmS24be = 65567, // PCM signed 24-bit big-endian
+  PcmS24le = 65548, // PCM signed 24-bit little-endian
+  PcmS24be = 65549, // PCM signed 24-bit big-endian
   Mp2 = 86016,      // MPEG Audio Layer 2
   Mp3 = 86017,      // MPEG Audio Layer 3
   Aac = 86018,      // Advanced Audio Coding
@@ -219,12 +219,12 @@ impl AVCodecID {
       78 => Self::Bmp,
       97 => Self::Gif,
       139 => Self::Vp8,
-      167 => Self::Vp9,
-      171 => Self::Webp,
-      173 => Self::Hevc,
-      225 => Self::Av1,
-      258 => Self::Jpegxl,
-      272 => Self::JpegxlAnim,
+      166 => Self::Vp9,
+      170 => Self::Webp,
+      172 => Self::Hevc,
+      222 => Self::Av1,
+      255 => Self::Jpegxl,
+      269 => Self::JpegxlAnim,
       65536 => Self::PcmS16le,
       65537 => Self::PcmS16be,
       65538 => Self::PcmU16le,
@@ -233,12 +233,12 @@ impl AVCodecID {
       65541 => Self::PcmU8,
       65544 => Self::PcmS32le,
       65545 => Self::PcmS32be,
+      65556 => Self::PcmF32be,
       65557 => Self::PcmF32le,
-      65558 => Self::PcmF32be,
+      65558 => Self::PcmF64be,
       65559 => Self::PcmF64le,
-      65560 => Self::PcmF64be,
-      65566 => Self::PcmS24le,
-      65567 => Self::PcmS24be,
+      65548 => Self::PcmS24le,
+      65549 => Self::PcmS24be,
       86016 => Self::Mp2,
       86017 => Self::Mp3,
       86018 => Self::Aac,
@@ -290,7 +290,7 @@ pub enum AVPixelFormat {
   Yuva420p10le = 87, // I420AP10
   Yuva422p10le = 89, // I422AP10
   Yuva444p10le = 91, // I444AP10
-  // Hardware formats - FFmpeg 8.x (libavutil 60) values
+  // Hardware formats - FFmpeg 9.x (libavutil 61) values
   // Verified against ffmpeg-src/FFmpeg/libavutil/pixfmt.h
   Videotoolbox = 157,
   Cuda = 117,
@@ -423,7 +423,7 @@ impl AVPixelFormat {
       87 => Self::Yuva420p10le,
       89 => Self::Yuva422p10le,
       91 => Self::Yuva444p10le,
-      // Hardware formats - FFmpeg 8.x (libavutil 60) values
+      // Hardware formats - FFmpeg 9.x (libavutil 61) values
       // Verified against ffmpeg-src/FFmpeg/libavutil/pixfmt.h
       157 => Self::Videotoolbox,
       117 => Self::Cuda,

--- a/tools/build-ffmpeg/src/main.rs
+++ b/tools/build-ffmpeg/src/main.rs
@@ -805,6 +805,39 @@ Cflags: -I${{includedir}}{}
     self.run_command_visible(&mut cmd)
   }
 
+  /// Clone a repository at a specific revision and reject stale source reuse.
+  fn git_clone_at_revision(&self, url: &str, revision: &str, dest: &Path) -> io::Result<()> {
+    self.git_clone(url, Some(revision), dest)?;
+
+    let resolve_revision = |revision: &str| -> io::Result<String> {
+      let output = Command::new("git")
+        .arg("-C")
+        .arg(dest)
+        .args(["rev-parse", "--verify", &format!("{revision}^{{commit}}")])
+        .output()?;
+
+      if !output.status.success() {
+        return Err(io::Error::other(format!(
+          "Source checkout {} does not contain requested revision {revision}; remove it and rerun",
+          dest.display()
+        )));
+      }
+
+      Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    };
+
+    let current_revision = resolve_revision("HEAD")?;
+    let requested_revision = resolve_revision(revision)?;
+    if current_revision != requested_revision {
+      return Err(io::Error::other(format!(
+        "Source checkout {} is at {current_revision}, not requested revision {revision} ({requested_revision}); remove it and rerun",
+        dest.display()
+      )));
+    }
+
+    Ok(())
+  }
+
   /// Download and extract a tarball
   fn download_tarball(&self, url: &str, dest: &Path) -> io::Result<()> {
     if dest.exists() {
@@ -2183,7 +2216,7 @@ Cflags: -I${{includedir}}
     self.info("Building FFmpeg...");
 
     let source = self.source_dir.join("FFmpeg");
-    self.git_clone(FFMPEG_REPO, Some(&self.ffmpeg_version), &source)?;
+    self.git_clone_at_revision(FFMPEG_REPO, &self.ffmpeg_version, &source)?;
 
     let prefix_str = self.prefix.to_string_lossy().to_string();
     let include_dir = self.prefix.join("include");
@@ -2663,9 +2696,34 @@ fn main() {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use std::time::{SystemTime, UNIX_EPOCH};
 
   fn args(values: &[&str]) -> Vec<String> {
     values.iter().map(|value| (*value).to_string()).collect()
+  }
+
+  fn run_git(directory: &Path, args: &[&str]) {
+    let status = Command::new("git")
+      .args(args)
+      .current_dir(directory)
+      .env("GIT_TERMINAL_PROMPT", "0")
+      .env("GIT_EDITOR", "true")
+      .status()
+      .unwrap();
+    assert!(status.success(), "git {args:?} failed");
+  }
+
+  fn temporary_directory(name: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .unwrap()
+      .as_nanos();
+    let directory = env::temp_dir().join(format!(
+      "webcodecs-node-{name}-{}-{nonce}",
+      std::process::id()
+    ));
+    fs::create_dir_all(&directory).unwrap();
+    directory
   }
 
   #[test]
@@ -2687,5 +2745,50 @@ mod tests {
       Err(error) => error,
     };
     assert_eq!(error, "Missing argument for --ffmpeg-version");
+  }
+
+  #[test]
+  fn rejects_reusing_checkout_at_different_revision() {
+    let root = temporary_directory("git-revision");
+    let repository = root.join("repository");
+    let checkout = root.join("checkout");
+    fs::create_dir_all(&repository).unwrap();
+
+    run_git(&repository, &["init", "--quiet"]);
+    run_git(&repository, &["config", "user.name", "Test User"]);
+    run_git(&repository, &["config", "user.email", "test@example.com"]);
+    run_git(&repository, &["config", "commit.gpgSign", "false"]);
+    run_git(&repository, &["config", "tag.gpgSign", "false"]);
+    fs::write(repository.join("version"), "n8.0\n").unwrap();
+    run_git(&repository, &["add", "version"]);
+    run_git(&repository, &["commit", "--quiet", "-m", "FFmpeg 8"]);
+    run_git(&repository, &["tag", "--no-sign", "n8.0"]);
+    fs::write(repository.join("version"), "n9.0\n").unwrap();
+    run_git(&repository, &["commit", "--quiet", "-am", "FFmpeg 9"]);
+    run_git(&repository, &["tag", "--no-sign", "n9.0"]);
+
+    let context = BuildContext::new(
+      root.join("output"),
+      root.join("source"),
+      None,
+      1,
+      false,
+      false,
+      true,
+    );
+    let repository_url = repository.to_string_lossy();
+    context
+      .git_clone_at_revision(&repository_url, "n8.0", &checkout)
+      .unwrap();
+    context
+      .git_clone_at_revision(&repository_url, "n8.0", &checkout)
+      .unwrap();
+
+    let error = context
+      .git_clone_at_revision(&repository_url, "n9.0", &checkout)
+      .unwrap_err();
+    assert!(error.to_string().contains("not requested revision n9.0"));
+
+    fs::remove_dir_all(root).unwrap();
   }
 }

--- a/tools/build-ffmpeg/src/main.rs
+++ b/tools/build-ffmpeg/src/main.rs
@@ -1,6 +1,6 @@
 //! FFmpeg build script for CI environments
 //!
-//! Builds FFmpeg 8.0.1 and all codec dependencies from source for Linux/FreeBSD targets.
+//! Builds FFmpeg 9.0 and all codec dependencies from source for Linux/FreeBSD targets.
 //! Usage: cargo run --release --bin build-ffmpeg -- [OPTIONS]
 
 use std::env;
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 // Version constants
-const FFMPEG_VERSION: &str = "n8.0.1";
+const DEFAULT_FFMPEG_VERSION: &str = "n9.0";
 const X264_REPO: &str = "https://code.videolan.org/videolan/x264.git";
 const X265_REPO: &str = "https://bitbucket.org/multicoreware/x265_git.git";
 const X265_BRANCH: &str = "Release_4.1";
@@ -44,6 +44,8 @@ const LIBJXL_BRANCH: &str = "v0.11.1";
 
 /// Build context containing all configuration
 struct BuildContext {
+  /// FFmpeg git tag to build
+  ffmpeg_version: String,
   /// Installation prefix for all libraries
   prefix: PathBuf,
   /// Directory for source code
@@ -133,6 +135,7 @@ impl BuildContext {
     };
 
     Self {
+      ffmpeg_version: DEFAULT_FFMPEG_VERSION.to_string(),
       prefix,
       source_dir,
       target,
@@ -143,6 +146,11 @@ impl BuildContext {
       use_system_cc,
       zig_wrapper_dir: None,
     }
+  }
+
+  fn with_ffmpeg_version(mut self, ffmpeg_version: String) -> Self {
+    self.ffmpeg_version = ffmpeg_version;
+    self
   }
 
   /// Ensure zig wrappers are created and return the wrapper directory
@@ -2175,7 +2183,7 @@ Cflags: -I${{includedir}}
     self.info("Building FFmpeg...");
 
     let source = self.source_dir.join("FFmpeg");
-    self.git_clone(FFMPEG_REPO, Some(FFMPEG_VERSION), &source)?;
+    self.git_clone(FFMPEG_REPO, Some(&self.ffmpeg_version), &source)?;
 
     let prefix_str = self.prefix.to_string_lossy().to_string();
     let include_dir = self.prefix.join("include");
@@ -2469,6 +2477,7 @@ USAGE:
     build-ffmpeg [OPTIONS]
 
 OPTIONS:
+    --ffmpeg-version <TAG>    FFmpeg git tag [default: n9.0]
     -o, --output <DIR>        Output installation directory [default: ./ffmpeg-build]
     -t, --target <TARGET>     Cross-compilation target [default: host]
     -s, --source-dir <DIR>    Directory for source code [default: ./ffmpeg-src]
@@ -2502,9 +2511,10 @@ EXAMPLE:
 }
 
 /// Parse command line arguments
-fn parse_args() -> Result<BuildContext, String> {
-  let args: Vec<String> = env::args().collect();
+fn parse_args_from(args: impl IntoIterator<Item = String>) -> Result<BuildContext, String> {
+  let args: Vec<String> = args.into_iter().collect();
 
+  let mut ffmpeg_version = DEFAULT_FFMPEG_VERSION.to_string();
   let mut output = PathBuf::from("./ffmpeg-build");
   let mut source_dir = PathBuf::from("./ffmpeg-src");
   let mut target: Option<String> = None;
@@ -2516,6 +2526,13 @@ fn parse_args() -> Result<BuildContext, String> {
   let mut i = 1;
   while i < args.len() {
     match args[i].as_str() {
+      "--ffmpeg-version" => {
+        i += 1;
+        if i >= args.len() {
+          return Err("Missing argument for --ffmpeg-version".to_string());
+        }
+        ffmpeg_version = args[i].clone();
+      }
       "-o" | "--output" => {
         i += 1;
         if i >= args.len() {
@@ -2579,15 +2596,22 @@ fn parse_args() -> Result<BuildContext, String> {
     source_dir
   };
 
-  Ok(BuildContext::new(
-    output,
-    source_dir,
-    target,
-    jobs,
-    verbose,
-    skip_deps,
-    use_system_cc,
-  ))
+  Ok(
+    BuildContext::new(
+      output,
+      source_dir,
+      target,
+      jobs,
+      verbose,
+      skip_deps,
+      use_system_cc,
+    )
+    .with_ffmpeg_version(ffmpeg_version),
+  )
+}
+
+fn parse_args() -> Result<BuildContext, String> {
+  parse_args_from(env::args())
 }
 
 fn main() {
@@ -2605,6 +2629,7 @@ fn main() {
   println!("========================================");
   println!("Output directory: {}", ctx.prefix.display());
   println!("Source directory: {}", ctx.source_dir.display());
+  println!("FFmpeg version: {}", ctx.ffmpeg_version);
   println!("Jobs: {}", ctx.jobs);
   if let Some(ref t) = ctx.target {
     println!("Target: {}", t);
@@ -2633,4 +2658,34 @@ fn main() {
   println!("To use the built FFmpeg, set:");
   println!("  export FFMPEG_DIR={}", ctx.prefix.display());
   println!();
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn args(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+  }
+
+  #[test]
+  fn defaults_to_latest_stable_ffmpeg() {
+    let context = parse_args_from(args(&["build-ffmpeg"])).unwrap();
+    assert_eq!(context.ffmpeg_version, "n9.0");
+  }
+
+  #[test]
+  fn accepts_ffmpeg_version_override() {
+    let context = parse_args_from(args(&["build-ffmpeg", "--ffmpeg-version", "n8.1.2"])).unwrap();
+    assert_eq!(context.ffmpeg_version, "n8.1.2");
+  }
+
+  #[test]
+  fn rejects_missing_ffmpeg_version() {
+    let error = match parse_args_from(args(&["build-ffmpeg", "--ffmpeg-version"])) {
+      Ok(_) => panic!("missing FFmpeg version should be rejected"),
+      Err(error) => error,
+    };
+    assert_eq!(error, "Missing argument for --ffmpeg-version");
+  }
 }


### PR DESCRIPTION
## Summary

- upgrade the FFmpeg build workflow and helper from 8.0.1 to stable 9.0
- update the FFmpeg 9 ABI guard and affected codec ID constants
- publish and pin checksummed `ffmpeg-n9.0` artifacts for all nine supported targets
- pin the Windows x64 codec build to Visual Studio 2022 and make release tags target the workflow commit

## Why

FFmpeg 9.0 is the current stable release. The previous workflow also had two latent pipeline issues: its Unix build helper ignored the workflow version input, and `windows-latest` moved to Visual Studio 2026 while the x265 multi-lib build requires the Visual Studio 2022 CMake generator.

The GitHub release action additionally defaulted new tags to the repository's default branch. The workflow now supplies `github.sha` explicitly so artifact releases point to the commit that built them.

## Impact

Default builds now download and verify the FFmpeg 9.0 static release. Explicit `FFMPEG_DIR` overrides must provide FFmpeg 9.x headers and libraries; FFmpeg 8.x is rejected by the ABI guard.

## Validation

- [Build FFmpeg Static run](https://github.com/Brooooooklyn/webcodecs-node/actions/runs/31319851433): all nine target builds and the release job passed
- [FFmpeg n9.0 release](https://github.com/Brooooooklyn/webcodecs-node/releases/tag/ffmpeg-n9.0): nine SHA-256-pinned assets, tag retargeted to the exact build commit
- `cargo test --lib`: 74 passed using the default release downloader, without `FFMPEG_DIR`
- `pnpm build --target aarch64-apple-darwin`: passed in release mode using the pinned release asset
- `pnpm test`: 1,069 passed, 15 expected skips
- `cargo test -p build-ffmpeg`: 3 passed
- `cargo clippy` and `cargo clippy -p build-ffmpeg --all-targets -- -D warnings`: passed
- `pnpm lint`, `pnpm typecheck`, `pnpm oxfmt --check`, `cargo fmt -- --check`, and `actionlint`: passed
- `gh attestation verify` passed for the published ARM64 macOS release asset

The Windows runner fix follows the official [`windows-latest` migration guidance](https://github.com/actions/runner-images/issues/14017).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a full native ABI bump (compile-time header guard, codec ID constants, and pinned binary artifacts); mismatched FFmpeg 8.x overrides or stale caches will fail builds or mis-decode until everyone uses the new `ffmpeg-n9.0` assets.
> 
> **Overview**
> **Upgrades the project from FFmpeg 8.0.1 to stable FFmpeg 9.0** for default downloads, CI builds, and the native FFI layer.
> 
> The **ABI guard** in `accessors.c` now requires libavcodec 63 / libavutil 61 / libavformat 63, and **`AVCodecID` / `from_raw` mappings** in `types.rs` are updated for FFmpeg 9’s shifted codec IDs (VP9, HEVC, AV1, JPEG XL, PCM variants, etc.). **`build.rs`** pins the `ffmpeg-n9.0` release tag and replaces all nine per-target archive SHA-256 digests.
> 
> **CI and tooling:** workflow defaults and `build-ffmpeg` default tag move to `n9.0`; Unix matrix jobs pass `--ffmpeg-version "$FFMPEG_VERSION"` so the workflow input is honored; Windows x64 uses **`windows-2022`** for x265’s VS 2022 CMake generator; release creation sets **`target_commitish: github.sha`** so tags point at the build commit. **`build-ffmpeg`** gains `--ffmpeg-version`, stores the tag on `BuildContext`, and uses **`git_clone_at_revision`** so reused checkouts cannot silently stay on the wrong tag (with tests).
> 
> **Docs:** README now states FFmpeg 9.x is required and FFmpeg 8.x is rejected when using `FFMPEG_DIR`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9675738a0c3f7021d302668e7edf2b59e6e42ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->